### PR TITLE
Added functionality to display time-dependant formatting

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
       }
     });
 
-    // on save-button click, take ID of parent div pair with input if not empty and save to localStorage 
+    // on save-button click, take ID of parent div pair with input (ifNot empty) and save to localStorage 
     saveButton.click(function() {
       const hourDivID = $(this).closest('div').attr('id');
       const textInput = $(this).siblings('textarea');
@@ -30,25 +30,24 @@ $(document).ready(function() {
       }
     });
 
+    // Get the 24-hour-of-day time in JS
+    let currentHour = dayjs().format("HH");
+    console.log(currentHour);
 
-    //
-    // TODO: Add code to apply the past, present, or future class to each time
-    // block by comparing the id to the current hour. HINTS: How can the id
-    // attribute of each time-block be used to conditionally add or remove the
-    // past, present, and future classes? How can Day.js be used to get the
-    // current hour in 24-hour time?
-    // Get(2 digit hour)
-      //if greater than ID-OUR = past
-      //else if equal present
-      //else () future
-      // advanced format plug in for ordinal advanced format plugin could help for 'kk' (2-dig year from 0 comparison)
-
-    //
-    // TODO: Add code to get any user input that was saved in localStorage and set
-    // the values of the corresponding textarea elements. HINT: How can the id
-    // attribute of each time-block be used to do this?
-    //
-
+    // Get all IDs that starts with "hour"
+    $('div[id^="hour"]').each(function() {
+      // Get the hour (last two digits) of the IDs
+      let classHour = $(this).attr('id').slice(-2);
+      console.log(classHour);
+      //compare hour of each class with current hour and apply conditional formatting by applying respective classes
+      if (classHour < currentHour) {
+        $(this).addClass("past");
+      } else if (classHour === currentHour) {
+        $(this).addClass("present");
+      } else {
+        $(this).addClass("future");
+      }
+    });
 
     // TODO: Add code to display the current date in the header of the page.
     let today = dayjs();

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         code is implemented.
         -->
 
-      <div id="hour-9" class="row time-block">
+      <div id="hour-09" class="row time-block">
         <div class="col-2 col-md-1 hour text-center py-3">9AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">


### PR DESCRIPTION
### `script.js`
- Added code to get time of day and compare with that in each container's ID, and apply relevant class (past/present/future).
- Added comments to above code.

### `index.html`
- In order to facilitate above, ID of `hour-9` changed to `hour-09` to accomodate 24-hour based comparison of `day.js` data with element ID.